### PR TITLE
stumpy 1.14.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "stumpy" %}
-{% set version = "1.13.0" %}
+{% set version = "1.14.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,11 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f29d3da980412150e7b029ab0cd8e7b132adcbf1c66ef7a4d35d564808bfba8a
+  sha256: 1cb13696724ddab4b512b16843d37ccf4047aee19e072d1ad83024e1fa6fde96
 
 build:
+  noarch: python
   number: 0
-  # skip for s390x as numba is not available on that platform.
-  skip: true  # [s390x or py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -20,12 +19,11 @@ requirements:
     - python
     - pip
     - setuptools
-    - setuptools-scm
   run:
     - python
-    - numpy >=1.21
+    - numpy >=1.24
     - scipy >=1.10
-    - numba >=0.57.1
+    - numba >=0.61.2
   run_constrained:
     - pandas >=0.20.0
     - dask-core >=1.2.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pip
     - wheel
     - setuptools
+    - setuptools-scm
   run:
     - python
     - numpy >=1.24

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,11 +35,9 @@ requirements:
 # test_snippets: AssertionError: Mismatched elements: 10 / 30 (33.3%)
 {% set deselect_tests = "--deselect=tests/test_precision.py::test_snippets" %}
 # test_cache_save_after_clear: uses a CWD-relative path to find numba cache files;
-# in conda build's isolated Linux test env the CWD has no stumpy/ subdir, so the
-# path never resolves. Not a stumpy algorithm test.
-{% if linux %}
+# in conda build's isolated test env the CWD has no stumpy/ subdir, so the
+# path never resolves on any platform. Not a stumpy algorithm test.
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_cache.py::test_cache_save_after_clear" %}
-{% endif %}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   host:
     - python
     - pip
+    - wheel
     - setuptools
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,15 @@ requirements:
     - black >=22.1.0
     - isort >=5.11.0
 
+# test_snippets: AssertionError: Mismatched elements: 10 / 30 (33.3%)
+{% set deselect_tests = "--deselect=tests/test_precision.py::test_snippets" %}
+# test_cache_save_after_clear: uses a CWD-relative path to find numba cache files;
+# in conda build's isolated Linux test env the CWD has no stumpy/ subdir, so the
+# path never resolves. Not a stumpy algorithm test.
+{% if linux %}
+{% set deselect_tests = deselect_tests + " --deselect=tests/test_cache.py::test_cache_save_after_clear" %}
+{% endif %}
+
 test:
   source_files:
     - tests
@@ -47,8 +56,7 @@ test:
     - polars >=1.14.0
   commands:
     - pip check
-    #E AssertionError: Mismatched elements: 10 / 30 (33.3%)
-    - pytest -v tests --deselect=tests/test_precision.py::test_snippets
+    - pytest -v tests {{ deselect_tests }}
 
 about:
   home: https://github.com/TDAmeritrade/stumpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # skip for s390x as numba is not available on that platform.
-  skip: true  # [s390x or py<310]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
     - pandas
     - dask-core
     - distributed
+    - polars >=1.14.0
   commands:
     - pip check
     #E AssertionError: Mismatched elements: 10 / 30 (33.3%)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,9 @@ source:
   sha256: 1cb13696724ddab4b512b16843d37ccf4047aee19e072d1ad83024e1fa6fde96
 
 build:
-  noarch: python
   number: 0
+  # skip for s390x as numba is not available on that platform.
+  skip: true  # [s390x or py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
stumpy 1.14.1 

**Destination channel:** Defaults

### Links

- [PKG-15600]
- dev_url:        https://github.com/TDAmeritrade/stumpy/tree/v1.14.1
- conda_forge:    https://github.com/conda-forge/stumpy-feedstock
- pypi:           https://pypi.org/project/stumpy/1.14.1
- pypi inspector: https://inspector.pypi.io/project/stumpy/1.14.1

### Explanation of changes:

- new version number


[PKG-15600]: https://anaconda.atlassian.net/browse/PKG-15600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ